### PR TITLE
[sidekick#51] Capabilities: add CapabilityId type + catalog module scaffold (1 stub entry)

### DIFF
--- a/Penny/src/renderer/src/capabilities/catalog.ts
+++ b/Penny/src/renderer/src/capabilities/catalog.ts
@@ -1,0 +1,22 @@
+export type CapabilityId = 'orchestrator'
+
+export interface CapabilityCatalogEntry {
+  title: string
+  blurb: string
+  validationSteps: string[]
+}
+
+export const CAPABILITY_CATALOG: Record<CapabilityId, CapabilityCatalogEntry> = {
+  orchestrator: {
+    title: 'Orchestrator',
+    blurb: 'Coordinates task queues and agent workflows across the Penny platform.',
+    validationSteps: [
+      'Confirm the orchestrator queue responds to list and dequeue operations.',
+      'Run a smoke pod workflow and verify status transitions.',
+    ],
+  },
+}
+
+export function listCapabilities(): CapabilityId[] {
+  return Object.keys(CAPABILITY_CATALOG) as CapabilityId[]
+}

--- a/Penny/src/renderer/src/capabilities/index.ts
+++ b/Penny/src/renderer/src/capabilities/index.ts
@@ -1,0 +1,2 @@
+export type { CapabilityId, CapabilityCatalogEntry } from './catalog'
+export { CAPABILITY_CATALOG, listCapabilities } from './catalog'

--- a/Penny/tests/renderer/capabilities/catalog.test.ts
+++ b/Penny/tests/renderer/capabilities/catalog.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CAPABILITY_CATALOG,
+  listCapabilities,
+} from '../../../src/renderer/src/capabilities/catalog'
+
+describe('capabilities catalog', () => {
+  it('has exactly one catalog entry', () => {
+    expect(Object.keys(CAPABILITY_CATALOG).length).toBe(1)
+    expect(listCapabilities().length).toBe(1)
+    expect(listCapabilities()[0]).toBe('orchestrator')
+  })
+})


### PR DESCRIPTION
Closes #51

Automated implementation by Penny orchestrator.