### PR TITLE
feat: self-healing pipeline with profile escalation

### DIFF
--- a/Penny/agents/CLAUDE.md
+++ b/Penny/agents/CLAUDE.md
@@ -88,24 +88,7 @@
 
 
 
-### Workflow: task (2026-04-13)
-- Task: task
-- Team: fullstack-dev / backend-arch / electron-dev
-- Result: PASS (2/2 iterations)
-- Key output: RESULT: PASS
 
-### Workflow: therealsiege/Penpal#196 (2026-04-13)
-- Task: Implement GitHub issue therealsiege/Penpal#196: Add .editorconfig for consistent formatting
-
-## Description
-
-Add a `.editorconfig` file to the repository root to enforce consistent code formatting acr
-- Team: fullstack-dev / backend-arch / electron-dev
-- Result: PASS (1/3 iterations)
-- Key output: ```
-RESULT: PASS
-Test Case 1: .editorconfig file exists at repo root - PASS
-  Details: The .editorconfig file has been successfully created in the rep
 
 ### Workflow: therealsiege/Penpal#197 (2026-04-13)
 - Task: Implement GitHub issue therealsiege/Penpal#197: Add .nvmrc file pinning Node 22
@@ -148,3 +131,23 @@ Extract the 5 hardcoded laser door beam positions from `gds-scene-renderer.ts` i
 - Team: fullstack-dev / backend-arch / electron-dev
 - Result: FAIL (1/5 iterations)
 - Key output: I'll implement the task to move laser door positions from hardcoded values in `gds-scene-renderer.ts` to `lab-map.json`. Let me first examine the curr
+
+### Workflow: therealsiege/Penpal#161 (2026-04-14)
+- Task: Implement GitHub issue therealsiege/Penpal#161: feat: Unified MCP server management panel in Penpal
+
+## Summary
+
+Full-page panel in Penpal that discovers, displays, toggles, and edits ALL MCP server c
+- Team: fullstack-dev / backend-arch / electron-dev
+- Result: PASS (1/5 iterations)
+- Key output: I'll execute the QA for the MCP server management panel implementation. Let me start by examining the task requirements and the implemented solution.
+
+### Workflow: therealsiege/Penpal#152 (2026-04-14)
+- Task: Implement GitHub issue therealsiege/Penpal#152: E2E: Laser door proximity animation tests
+
+## Summary
+
+Create Playwright E2E tests for the 5 purple laser doorways that fade open when agents approach a
+- Team: fullstack-dev / backend-arch / electron-dev
+- Result: PASS (2/5 iterations)
+- Key output: I'll help you implement the actual Playwright E2E tests for the laser door proximity animation. First, let me check the current state of the test file

--- a/Penny/src/main/github-pipeline.ts
+++ b/Penny/src/main/github-pipeline.ts
@@ -455,7 +455,9 @@ export async function ingestIssue(config: RepoConfig, issue: GHIssue): Promise<P
     return existing
   }
 
-  const runtimeProfile = deriveRuntimeProfile(issue.labels)
+  // Preserve escalated profile from previous retry, fall back to label-derived
+  const runtimeProfile = existing?.runtimeProfile || deriveRuntimeProfile(issue.labels)
+  const retryCount = existing?.retryCount ?? 0
   const presetId = derivePresetFromLabels(issue.labels)
 
   const entry: PipelineIssue = {
@@ -466,6 +468,8 @@ export async function ingestIssue(config: RepoConfig, issue: GHIssue): Promise<P
     stage: 'executing',
     priority: 'normal',
     runtimeProfile,
+    retryCount,
+    maxRetries: 2,
     ingestedAt: Date.now(),
     updatedAt: Date.now(),
   }
@@ -627,10 +631,19 @@ export async function drivePipeline(repos: RepoConfig[]): Promise<void> {
       const isBranchError = errorMsg.includes('already exists') || errorMsg.includes('worktree')
 
       if (retries < maxRetries) {
-        // ── Auto-retry: clean up stale branches and re-queue ──
+        // ── Auto-retry: clean up + escalate profile ──
         tracked.retryCount = retries + 1
         tracked.lastError = errorMsg
         tracked.updatedAt = Date.now()
+
+        // Escalate profile on retry: economic → sonnet → max
+        const prevProfile = tracked.runtimeProfile || 'economic'
+        const escalation: Record<string, string> = { economic: 'sonnet', sonnet: 'max' }
+        const nextProfile = isBranchError ? prevProfile : (escalation[prevProfile] || prevProfile)
+        if (nextProfile !== prevProfile) {
+          tracked.runtimeProfile = nextProfile
+          console.log(`[github-pipeline] Escalating #${tracked.number} profile: ${prevProfile} → ${nextProfile}`)
+        }
 
         // Clean up stale branch that might block the next attempt
         if (tracked.branch) {
@@ -649,13 +662,13 @@ export async function drivePipeline(repos: RepoConfig[]): Promise<void> {
         tracked.worktreePath = undefined
         tracked.podWorkflowId = undefined
 
-        console.log(`[github-pipeline] Auto-retry #${tracked.number} (attempt ${tracked.retryCount}/${maxRetries})${isBranchError ? ' — cleaned stale branch' : ''}`)
+        const escalateNote = nextProfile !== prevProfile ? ` — escalating to **${nextProfile}**` : ''
+        console.log(`[github-pipeline] Auto-retry #${tracked.number} (attempt ${tracked.retryCount}/${maxRetries})${isBranchError ? ' — cleaned stale branch' : ''}${escalateNote}`)
 
         await Promise.allSettled([
           addComment(config, tracked.number,
-            `**Auto-retrying** (attempt ${tracked.retryCount}/${maxRetries})${isBranchError ? ' — cleaned stale branch/worktree' : ''}\n\n\`\`\`\n${errorMsg.slice(0, 500)}\n\`\`\``,
+            `**Auto-retrying** (attempt ${tracked.retryCount}/${maxRetries})${escalateNote}${isBranchError ? ' — cleaned stale branch/worktree' : ''}\n\n\`\`\`\n${errorMsg.slice(0, 500)}\n\`\`\``,
           ),
-          // Re-add agent-ready so the poller picks it up again
           setLabel(config, tracked.number, ['agent-executing'], 'agent-ready'),
         ])
         saveState()


### PR DESCRIPTION
## Summary
- **Auto-retry failed pods** with stale branch/worktree cleanup before re-queue
- **Escalate runtime profile on retry** (economic → sonnet → max) so harder tasks get more capacity on subsequent attempts
- Preserve escalated profile across re-ingestion to prevent reset

## Test plan
- [ ] Trigger a pod failure on an `economic` profile issue — verify retry escalates to `sonnet`
- [ ] Verify branch error retries do NOT escalate (same tier, just cleanup)
- [ ] Confirm GitHub comment includes escalation note
- [ ] Verify `retryCount` persists across `ingestIssue` re-ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)