### PR TITLE
Implement GitHub issue therealsiege/Penpal#251: Living Lab 6b: Task life

### DIFF
--- a/Penny/src/renderer/src/game/celebrations.ts
+++ b/Penny/src/renderer/src/game/celebrations.ts
@@ -430,6 +430,92 @@ export class CelebrationManager {
     }
   }
 
+  /**
+   * Task start VFX — expanding white ring (0→40px, 400ms) + 3–4 sparkle particles.
+   * Fires immediately (not queued) when an agent transitions idle→working.
+   */
+  taskStart(x: number, y: number): void {
+    if (!this._celebrationsAllowed) return
+    this._playTaskStart(x, y)
+  }
+
+  private _playTaskStart(x: number, y: number): void {
+    // Expanding white ring: radius 0→40px, alpha 1→0, 400ms
+    const gfx = this._scene.add.graphics().setDepth(599)
+    this._scene.tweens.addCounter({
+      from: 0,
+      to: 1,
+      duration: 400,
+      ease: 'Sine.easeOut',
+      onUpdate: (tween) => {
+        const t = tween.getValue() ?? 0
+        const r = t * 40
+        const a = (1 - t) * 0.75
+        gfx.clear()
+        gfx.lineStyle(2.5 * (1 - t * 0.5), 0xffffff, a)
+        gfx.strokeCircle(x, y, r)
+      },
+      onComplete: () => gfx.destroy(),
+    })
+
+    // 3–4 sparkle particles fly outward
+    const count = 3 + Math.floor(Math.random() * 2)
+    for (let i = 0; i < count; i++) {
+      const p = this._sparklePool.find(c => !c.getData('busy'))
+      if (!p) continue
+      const angle = (i / count) * Math.PI * 2 + (Math.random() - 0.5) * 0.6
+      const dist = 8 + Math.random() * 10
+      const sy = y - 8
+      p.setPosition(x, sy)
+      p.setFillStyle(0xffffff)
+      p.setRadius(0.9 + Math.random() * 0.8)
+      p.setAlpha(0.9).setVisible(true).setData('busy', true)
+      this._scene.tweens.add({
+        targets: p,
+        x: x + Math.cos(angle) * dist,
+        y: sy + Math.sin(angle) * dist,
+        alpha: 0,
+        duration: 300 + Math.random() * 100,
+        ease: 'Power2',
+        onComplete: () => { p.setVisible(false).setData('busy', false) },
+      })
+    }
+  }
+
+  /**
+   * Task fail VFX — red pulse ring + brief screen-edge red flash (100ms).
+   * Enqueued at 'error' priority alongside the existing error() celebration.
+   */
+  taskFail(x: number, y: number, opts?: CelebrationOptions): void {
+    this._enqueueCelebration('error', opts, null, (e) => {
+      e.run = () => this._playTaskFail(x, y)
+    })
+  }
+
+  private _playTaskFail(x: number, y: number): void {
+    this._expandingRing(x, y, 0xef4444)
+    this._screenEdgeFlash(0xef4444, 100)
+  }
+
+  /** Screen-edge flash — fills only the border of the viewport with the given color. */
+  private _screenEdgeFlash(color: number, durationMs: number): void {
+    const cam = this._scene.cameras.main
+    const flash = this._scene.add.graphics().setScrollFactor(0).setDepth(9999)
+    const bw = 18
+    flash.fillStyle(color, 0.45)
+    flash.fillRect(0, 0, cam.width, bw)
+    flash.fillRect(0, cam.height - bw, cam.width, bw)
+    flash.fillRect(0, bw, bw, cam.height - bw * 2)
+    flash.fillRect(cam.width - bw, bw, bw, cam.height - bw * 2)
+    this._scene.tweens.add({
+      targets: flash,
+      alpha: 0,
+      duration: durationMs,
+      ease: 'Power2',
+      onComplete: () => flash.destroy(),
+    })
+  }
+
   private _comboFloatingLabel(streak: number): void {
     const cam = this._scene.cameras.main
     const cx = cam.width / 2

--- a/Penny/src/renderer/src/game/office-types.ts
+++ b/Penny/src/renderer/src/game/office-types.ts
@@ -194,6 +194,10 @@ export interface WorkstationSprite {
   contextRotShakeTween?: Phaser.Tweens.Tween
   lastContextRotState?: boolean
   contextRotMonitorBaseX?: number
+  /** Yellow rotating arc ring shown during accept-edits review phase */
+  taskReviewRing?: Phaser.GameObjects.Graphics
+  /** Counter tween driving the review ring rotation angle */
+  taskReviewRingTween?: Phaser.Tweens.Tween
 }
 
 export interface Room {

--- a/Penny/src/renderer/src/game/workstation-animation.ts
+++ b/Penny/src/renderer/src/game/workstation-animation.ts
@@ -199,6 +199,9 @@ export class WorkstationAnimator {
     if (ws.chairSprite) ws.chairSprite.setAngle(0)
     // Clear typing note timer
     if (ws.typingNoteTimer) { ws.typingNoteTimer.destroy(); ws.typingNoteTimer = undefined }
+    // Clear task-review ring (accept-edits waiting state)
+    if (ws.taskReviewRingTween) { ws.taskReviewRingTween.destroy(); ws.taskReviewRingTween = undefined }
+    if (ws.taskReviewRing) { ws.taskReviewRing.destroy(); ws.taskReviewRing = undefined }
     // Clear speech bubble
     if (ws.speechBubbleTween) { ws.speechBubbleTween.destroy(); ws.speechBubbleTween = undefined }
     if (ws.speechBubbleTimer) { ws.speechBubbleTimer.destroy(); ws.speechBubbleTimer = undefined }
@@ -291,6 +294,29 @@ export class WorkstationAnimator {
           duration: AnimConfig.waiting.ledFadeDuration, ease: 'Sine.easeOut',
         })
       }
+      // Task review ring — yellow rotating arc during accept-edits review phase
+      if (agent.interactionType === 'accept-edits') {
+        const reviewRing = this.scene.add.graphics()
+        ws.container.add(reviewRing)
+        ws.taskReviewRing = reviewRing
+        const REVIEW_RING_R = 14
+        ws.taskReviewRingTween = this.scene.tweens.addCounter({
+          from: 0,
+          to: Math.PI * 2,
+          duration: 1600,
+          repeat: -1,
+          ease: 'Linear',
+          onUpdate: (tween) => {
+            if (!reviewRing.active) return
+            const a = tween.getValue() ?? 0
+            reviewRing.clear()
+            reviewRing.lineStyle(1.5, 0xfbbf24, 0.75)
+            reviewRing.beginPath()
+            reviewRing.arc(0, WS_SPRITE_Y, REVIEW_RING_R, a, a + Math.PI * 1.1, false)
+            reviewRing.strokePath()
+          },
+        })
+      }
       this.restoreDeskStrokeCallback(ws)
     } else if (isWorking) {
       if (!gdsLock) ws.sprite.setFrame(base + POSE_INTERACT)
@@ -349,6 +375,16 @@ export class WorkstationAnimator {
           if (ws.questIconTween) { ws.questIconTween.destroy(); ws.questIconTween = undefined }
           if (ws.questIconPulseTween) { ws.questIconPulseTween.destroy(); ws.questIconPulseTween = undefined }
           this._applyQuestStarStyle(ws, activeQ.difficulty as QuestDifficulty)
+        }
+
+        // Task start VFX: expanding white ring + sparkles (idle→working)
+        for (const room of this.host.getRooms().values()) {
+          if (room.workstations.has(agent.config.id)) {
+            const worldX = room.x + ws.container.x
+            const worldY = room.y + ws.container.y + WS_SPRITE_Y
+            this.host.celebrations.taskStart(worldX, worldY)
+            break
+          }
         }
       }
       // LED: working — green pulsing glow
@@ -570,7 +606,12 @@ export class WorkstationAnimator {
           if (room.workstations.has(agent.config.id)) {
             const worldX = room.x + ws.container.x
             const worldY = room.y + ws.container.y - 16  // slightly above the agent head
-            this.host.burstConfetti(worldX, worldY)
+            if (agent.sessionMode === 'error' || agent.sessionMode === 'crashed') {
+              // Task failed — play fail VFX instead of confetti
+              this.host.celebrations.taskFail(worldX, worldY + 16, { agentId: agent.config.id })
+            } else {
+              this.host.burstConfetti(worldX, worldY)
+            }
             break
           }
         }


### PR DESCRIPTION
Automated implementation by pod-cli.

Task: Implement GitHub issue therealsiege/Penpal#251: Living Lab 6b: Task lifecycle VFX — start, complete, fail, review. Parent: #233. Task start (idle→working): expanding ring from agent (white, 0→40px, alpha 1→0, 400ms) + 3-4 sparkle particles fly outward. Task complete: keep existing green checkmark. Task fail: red pulse ring + brief screen-edge red flash (100ms). Task review: yellow rotating ring around agent during review phase. All VFX use sprite-based particles from GAME_ICONS sheet. npx tsc --