### PR TITLE
Implement GitHub issue therealsiege/Penpal#360: Combo analytics auto-rou

### DIFF
--- a/Penny/src/main/evals/collectors/pod-combos.ts
+++ b/Penny/src/main/evals/collectors/pod-combos.ts
@@ -335,6 +335,21 @@ export class PodComboCollector {
 
     return stats
   }
+
+  /**
+   * Suggest the best-performing agent combo with at least `minRuns` completed runs.
+   * Optionally filter by preset. Returns null if no combo qualifies.
+   */
+  suggestBestCombo(opts?: { presetId?: string; minRuns?: number }): ComboStats | null {
+    const minRuns = opts?.minRuns ?? 3
+    const report = this.report(opts?.presetId ? { presetId: opts.presetId } : undefined)
+
+    const qualified = report.topCombos.filter(c => c.totalRuns >= minRuns)
+    if (qualified.length === 0) return null
+
+    // topCombos is already sorted by successRate desc, avgCompletionTime asc
+    return qualified[0]
+  }
 }
 
 // ── Singleton ───────────────────────────────────────────────────────────────

--- a/Penny/src/main/pods.ts
+++ b/Penny/src/main/pods.ts
@@ -1836,6 +1836,22 @@ export function createPod(task: string, opts: CreatePodOpts = {}): PodWorkflow {
     solver = opts.solverAgent || preset.solver
     reviewer = opts.reviewerAgent || preset.reviewer
     executor = opts.executorAgent || preset.executor
+  } else if (!opts.solverAgent && !opts.reviewerAgent && !opts.executorAgent) {
+    // No preset and no explicit agents — try combo analytics auto-routing
+    const suggested = podComboCollector.suggestBestCombo()
+    if (suggested) {
+      solver = suggested.solverId
+      reviewer = suggested.reviewerId
+      executor = suggested.executorId
+      console.log(
+        `[pods] Auto-routing: selected combo ${suggested.comboKey} ` +
+        `(${suggested.totalRuns} runs, ${(suggested.successRate * 100).toFixed(0)}% success rate)`,
+      )
+    } else {
+      solver = 'fullstack-dev'
+      reviewer = 'backend-arch'
+      executor = 'electron-dev'
+    }
   } else {
     solver = opts.solverAgent || 'fullstack-dev'
     reviewer = opts.reviewerAgent || 'backend-arch'


### PR DESCRIPTION
Automated implementation by pod-cli.

Task: Implement GitHub issue therealsiege/Penpal#360: Combo analytics auto-routing. Add suggestBestCombo(taskKeywords?) to src/main/evals/collectors/pod-combos.ts that returns the highest success-rate combo with 3+ runs. Wire it into createPod() in pods.ts as a fallback when no preset is specified — if combo analytics have sufficient data, auto-select the best-performing agent triple. Log the auto-selection.