### PR TITLE
Implement GitHub issue therealsiege/Penpal#359: Activate DPO pair genera

### DIFF
--- a/Penny/src/main/ipc.ts
+++ b/Penny/src/main/ipc.ts
@@ -175,6 +175,24 @@ export const ipcEvents = new EventEmitter()
 const VAULT_ROOT = DOCS_ROOT
 const BRIEFINGS_DIR = path.join(VAULT_ROOT, '1Putt', 'Daily Briefings')
 const DATA_DIR = path.resolve(__dirname, '..', '..', 'data')
+const DPO_PAIRS_FILENAME = 'dpo-pairs.jsonl'
+
+function resolveDataExportPath(fileName: string): string {
+  const dataDir = path.resolve(DATA_DIR)
+  const safeName = path.basename(fileName)
+  if (safeName !== fileName) {
+    throw new Error(`Invalid export filename: ${fileName}`)
+  }
+  if (path.extname(safeName).toLowerCase() !== '.jsonl') {
+    throw new Error('DPO export file must use .jsonl extension')
+  }
+  const outPath = path.resolve(dataDir, safeName)
+  const relative = path.relative(dataDir, outPath)
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Invalid export path outside data directory: ${outPath}`)
+  }
+  return outPath
+}
 
 interface VaultFolder {
   name: string
@@ -1500,6 +1518,44 @@ export function registerIpcHandlers() {
 }
 
 export function registerPreferenceIpc(store: PreferenceStore) {
+  const runDpoPairExport = async (): Promise<{ count: number; path: string }> => {
+    const { PairGenerator } = await import('./preferences/pairs')
+    const generator = new PairGenerator(store)
+    const dataDir = path.resolve(DATA_DIR)
+    const outPath = resolveDataExportPath(DPO_PAIRS_FILENAME)
+
+    await fs.promises.mkdir(dataDir, { recursive: true })
+    const dataDirStat = await fs.promises.stat(dataDir)
+    if (!dataDirStat.isDirectory()) {
+      throw new Error(`Data path is not a directory: ${dataDir}`)
+    }
+    await fs.promises.access(dataDir, fs.constants.W_OK)
+
+    let generatedCount = 0
+    try {
+      for await (const _pair of generator.generate()) {
+        generatedCount++
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`Failed to generate DPO pairs from preferences: ${message}`)
+    }
+    if (!Number.isInteger(generatedCount) || generatedCount < 0) {
+      throw new Error(`Invalid DPO pair count generated: ${generatedCount}`)
+    }
+
+    try {
+      const count = await generator.export(outPath, 'jsonl')
+      if (!Number.isInteger(count) || count < 0) {
+        throw new Error(`Invalid DPO pair export count: ${count}`)
+      }
+      return { count, path: outPath }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`Failed to export DPO pairs to ${outPath}: ${message}`)
+    }
+  }
+
   ipcMain.handle('preferences:stats', wrapHandler(() => store.stats()))
   ipcMain.handle('preferences:count', wrapHandler(() => store.count()))
   ipcMain.handle('preferences:query', wrapHandler(async (filter?: unknown) => {
@@ -1515,14 +1571,8 @@ export function registerPreferenceIpc(store: PreferenceStore) {
     }
     return events
   }))
-  ipcMain.handle('preferences:generate-pairs', wrapHandler(async () => {
-    const { PairGenerator } = await import('./preferences/pairs')
-    const generator = new PairGenerator(store)
-    const dataDir = path.resolve(__dirname, '..', 'data')
-    const outPath = path.join(dataDir, 'dpo-pairs.jsonl')
-    const count = await generator.export(outPath, 'jsonl')
-    return { count, path: outPath }
-  }))
+  ipcMain.handle('preferences:generate-pairs', wrapHandler(runDpoPairExport))
+  ipcMain.handle('evals:generate-dpo-pairs', wrapHandler(runDpoPairExport))
 
   // ── Pod Stage Change Forwarding ──────────────────────────────────────────
   // Forward pod status-change events to the renderer for spectator mode

--- a/Penny/src/preload/index.ts
+++ b/Penny/src/preload/index.ts
@@ -4,6 +4,18 @@ import { contextBridge, ipcRenderer } from 'electron'
 const unwrap = <T>(result: T): T =>
   (result && typeof result === 'object' && 'data' in result && 'summary' in result) ? (result as { data: T }).data : result
 
+const throwOnIpcError = <T>(result: T): T => {
+  if (
+    result &&
+    typeof result === 'object' &&
+    'error' in result &&
+    typeof (result as { error?: unknown }).error === 'string'
+  ) {
+    throw new Error((result as { error: string }).error)
+  }
+  return result
+}
+
 contextBridge.exposeInMainWorld('pty', {
   create: (cwd: string, command?: string, args?: string[], env?: Record<string, string>) =>
     ipcRenderer.invoke('pty:create', cwd, command, args, env),
@@ -138,7 +150,7 @@ contextBridge.exposeInMainWorld('api', {
   preferencesCount: () => ipcRenderer.invoke('preferences:count'),
   preferencesQuery: (filter?: { agentId?: string; signal?: string; since?: string }) =>
     ipcRenderer.invoke('preferences:query', filter),
-  preferencesGeneratePairs: () => ipcRenderer.invoke('preferences:generate-pairs'),
+  preferencesGeneratePairs: () => ipcRenderer.invoke('preferences:generate-pairs').then(throwOnIpcError),
   // Config Snapshot + Editing
   getConfigSnapshot: () => ipcRenderer.invoke('config:snapshot'),
   addProjectMcpServer: (server: { name: string; command: string; args: string[]; env?: Record<string, string>; cwd?: string }) =>
@@ -193,6 +205,8 @@ contextBridge.exposeInMainWorld('api', {
   evalsSpotCheckSample: (count: number) => ipcRenderer.invoke('evals:spot-check-sample', count),
   evalsSpotCheckReview: (id: string, verdict: string, notes?: string) => ipcRenderer.invoke('evals:spot-check-review', id, verdict, notes),
   evalsSpotCheckAgreement: () => ipcRenderer.invoke('evals:spot-check-agreement'),
+  // DPO Pair Generation
+  evalsGenerateDpoPairs: () => ipcRenderer.invoke('evals:generate-dpo-pairs').then(throwOnIpcError),
   // Pod Stage Change (spectator mode)
   onPodStageChanged: (callback: (event: { podId: string; status: string; solverId: string; reviewerId: string; executorId: string; iteration: number }) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: { podId: string; status: string; solverId: string; reviewerId: string; executorId: string; iteration: number }) => callback(data)

--- a/Penny/src/renderer/src/env.d.ts
+++ b/Penny/src/renderer/src/env.d.ts
@@ -177,6 +177,7 @@ declare global {
       evalsSpotCheckSample: (count: number) => Promise<import('./types').SpotCheck[]>
       evalsSpotCheckReview: (id: string, verdict: 'pass' | 'fail' | 'partial', notes?: string) => Promise<void>
       evalsSpotCheckAgreement: () => Promise<import('./types').SpotCheckAgreement>
+      evalsGenerateDpoPairs: () => Promise<{ count: number; path: string }>
       // Pod Quality Metrics
       evalsPodQuality: (since?: string) => Promise<{
         period: { from: string; to: string }

--- a/Penny/src/renderer/src/panels/EvalsPanel.tsx
+++ b/Penny/src/renderer/src/panels/EvalsPanel.tsx
@@ -389,6 +389,92 @@ function PodCombosSection() {
   )
 }
 
+function DpoPairsSection() {
+  const [generating, setGenerating] = useState(false)
+  const [result, setResult] = useState<{ count: number; path: string } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleGenerate = useCallback(async () => {
+    setGenerating(true)
+    setError(null)
+    setResult(null)
+    try {
+      const res = await window.api.evalsGenerateDpoPairs()
+      if (
+        typeof res?.count !== 'number' ||
+        !Number.isFinite(res.count) ||
+        res.count < 0 ||
+        typeof res.path !== 'string' ||
+        res.path.trim().length === 0
+      ) {
+        throw new Error('Main process returned an invalid DPO export result.')
+      }
+      setResult({ count: Math.trunc(res.count), path: res.path })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setError(`Failed to generate DPO pairs: ${message}`)
+    } finally {
+      setGenerating(false)
+    }
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-bold text-[var(--c-text-heading)] tracking-tight">DPO Pairs</h2>
+        <div className="flex items-center gap-3">
+          {result && (
+            <span className="text-xs text-[var(--c-text-secondary)]">
+              <span className="font-semibold text-[var(--c-text-bright)]">{result.count}</span> pairs exported
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={handleGenerate}
+            disabled={generating}
+            aria-busy={generating}
+            aria-label="Generate DPO training pairs from preference data"
+            className="px-3 py-1 rounded bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-xs font-semibold text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+          >
+            {generating ? 'Generating...' : 'Generate Pairs'}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-800/80 bg-red-950/40 px-4 py-3 text-sm text-red-100"
+        >
+          {error}
+        </div>
+      )}
+
+      {generating && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-xl border border-indigo-900/60 bg-indigo-950/40 px-4 py-3 text-sm text-indigo-100"
+        >
+          Generating DPO pairs from preferences...
+        </div>
+      )}
+
+      {!result && !error && !generating && (
+        <div className="rounded-xl bg-[var(--c-bg-surface)]/50 border border-[var(--c-border-subtle)] px-5 py-6 text-center text-[var(--c-text-muted)] text-sm">
+          Generate DPO training pairs from preference signals. Output: data/dpo-pairs.jsonl
+        </div>
+      )}
+
+      {result && (
+        <div className="rounded-xl bg-[var(--c-bg-surface)]/50 border border-[var(--c-border-subtle)] px-5 py-3 text-sm text-[var(--c-text-secondary)]">
+          Exported <span className="font-semibold text-[var(--c-text-bright)]">{result.count}</span> pairs to <span className="font-mono text-xs text-[var(--c-text-muted)]">{result.path}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
 function SpotCheckSection() {
   const { data: pending, refresh: refreshPending } = usePolling<SpotCheck[]>(
     () => window.api.evalsSpotCheckQueue(),
@@ -560,6 +646,7 @@ export function EvalsPanel() {
           </div>
         )}
 
+        <DpoPairsSection />
         <PodCombosSection />
         <SpotCheckSection />
       </div>

--- a/Penny/tests/renderer/panels/EvalsPanel.test.tsx
+++ b/Penny/tests/renderer/panels/EvalsPanel.test.tsx
@@ -67,6 +67,24 @@ describe('EvalsPanel', () => {
     ;(usePolling as unknown as ReturnType<typeof vi.fn>)
       .mockReturnValueOnce({ data: mockReports, loading: false, error: null, errorCount: 0, refresh: vi.fn() })
       .mockReturnValueOnce({ data: mockStats, loading: false, error: null, errorCount: 0, refresh: vi.fn() })
+      .mockReturnValueOnce({
+        data: {
+          period: { from: '2026-03-22', to: '2026-03-29' },
+          totalPods: 0,
+          topCombos: [],
+          agentRoleStats: [],
+          stageTimingOverall: {
+            avgSolving_ms: 0,
+            avgReviewing_ms: 0,
+            avgExecuting_ms: 0,
+            avgSelfFixing_ms: 0,
+          },
+        },
+        loading: false,
+        error: null,
+        errorCount: 0,
+        refresh: vi.fn(),
+      })
       .mockReturnValueOnce({ data: [], loading: false, error: null, errorCount: 0, refresh: vi.fn() })
       .mockReturnValueOnce({ data: { total: 0, agreed: 0, rate: 0 }, loading: false, error: null, errorCount: 0, refresh: vi.fn() })
   })

--- a/Penny/tests/setup/renderer.setup.ts
+++ b/Penny/tests/setup/renderer.setup.ts
@@ -1,5 +1,21 @@
 import { afterEach, vi } from 'vitest'
 
+if (typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
 // jsdom renderer tests: reset DOM between cases. Prefer factory data from tests/helpers/factories.ts
 // for AgentState/Task/PodWorkflow/PreferenceEvent in main-oriented tests; renderer duplicate types live
 // in src/renderer/src/types.ts — import the layer-appropriate type for the code under test.


### PR DESCRIPTION
Automated implementation by pod-cli.

Task: Implement GitHub issue therealsiege/Penpal#359: Activate DPO pair generator. 101 preference pairs exist in data/preferences.jsonl. The PairGenerator in src/main/preferences/pairs.ts has generate() and export() methods but they're never called. Add an IPC handler evals:generate-dpo-pairs that calls PairGenerator.generate() and exports to data/dpo-pairs.jsonl. Add a button in EvalsPanel to trigger generation and show pair count.